### PR TITLE
Much faster conversion from Skia to Pillow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,4 @@ jobs:
       run: poetry install
       if: steps.cached-dependencies.outputs.cache-hit != 'true'
     - name: Test
-      run: poetry run pytest tests --cov=./ --cov-report=xml
-#    - name: "Upload coverage to Codecov"
-#      uses: codecov/codecov-action@v2
-#      with:
-#        fail_ci_if_error: true
-#        token: ${{ secrets.CODECOV_TOKEN }}
+      run: poetry run pytest tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -870,13 +870,13 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-
 
 [[package]]
 name = "pluggy"
-version = "1.4.0"
+version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
-    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
 ]
 
 [package.extras]
@@ -973,13 +973,13 @@ dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pytest"
-version = "8.0.0"
+version = "8.2.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"},
-    {file = "pytest-8.0.0.tar.gz", hash = "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c"},
+    {file = "pytest-8.2.1-py3-none-any.whl", hash = "sha256:faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1"},
+    {file = "pytest-8.2.1.tar.gz", hash = "sha256:5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd"},
 ]
 
 [package.dependencies]
@@ -987,11 +987,11 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=1.3.0,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+pluggy = ">=1.5,<2.0"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -1609,4 +1609,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "4f86182ea3ff9bda69bc9cf1329aeda87b90c53dbc328f488cd2583bf01c3141"
+content-hash = "c76bc19e8dc2145a521716760ebfc7de7d7ad9fe338efe03c10edb303aa58d63"

--- a/poetry.lock
+++ b/poetry.lock
@@ -995,13 +995,13 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
-    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
 ]
 
 [package.dependencies]
@@ -1009,7 +1009,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-watch"
@@ -1609,4 +1609,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "c76bc19e8dc2145a521716760ebfc7de7d7ad9fe338efe03c10edb303aa58d63"
+content-hash = "dc64ad135d3330a21f99bc42073a1f72a820a93f2c3474546acae8b0874ef6e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ Pillow = "^10.2.0"
 skia-python = {version = "^121.0b6", allow-prereleases = true}
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.0.0"
+pytest = "^8.2.1"
 pytest-watch = "^4.2.0"
 pytest-cov = "^3.0.0"
 pylint = "^3.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ skia-python = {version = "^121.0b6", allow-prereleases = true}
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.1"
 pytest-watch = "^4.2.0"
-pytest-cov = "^3.0.0"
+pytest-cov = "^5.0.0"
 pylint = "^3.0.2"
 pycodestyle = "^2.8.0"
 Sphinx = "^5.2.3"

--- a/pytamaro/io.py
+++ b/pytamaro/io.py
@@ -15,7 +15,7 @@ from typing import List
 from PIL import Image as PILImageMod
 from PIL.Image import Image as PILImage
 from skia import (Canvas, FILEWStream, Image, Rect, Surface, SVGCanvas, kPNG,
-                  kUnpremul_AlphaType)
+                  kRGBA_8888_ColorType, kUnpremul_AlphaType)
 
 from pytamaro.checks import check_graphic, check_type
 from pytamaro.debug import add_debug_info
@@ -101,7 +101,9 @@ def graphic_to_pillow_image(graphic: Graphic) -> PILImage:
     :param graphic: graphic to be rendered and converted
     :returns: rendered graphic as a Pillow image
     """
-    return PILImageMod.fromarray(graphic_to_image(graphic).convert(alphaType=kUnpremul_AlphaType))
+    return PILImageMod.fromarray(graphic_to_image(graphic).convert(
+        alphaType=kUnpremul_AlphaType, colorType=kRGBA_8888_ColorType)
+    )
 
 
 # pylint: disable-next=invalid-name

--- a/pytamaro/io.py
+++ b/pytamaro/io.py
@@ -14,7 +14,8 @@ from typing import List
 
 from PIL import Image as PILImageMod
 from PIL.Image import Image as PILImage
-from skia import Canvas, FILEWStream, Image, Rect, Surface, SVGCanvas, kPNG
+from skia import (Canvas, FILEWStream, Image, Rect, Surface, SVGCanvas, kPNG,
+                  kUnpremul_AlphaType)
 
 from pytamaro.checks import check_graphic, check_type
 from pytamaro.debug import add_debug_info
@@ -100,10 +101,7 @@ def graphic_to_pillow_image(graphic: Graphic) -> PILImage:
     :param graphic: graphic to be rendered and converted
     :returns: rendered graphic as a Pillow image
     """
-    with io.BytesIO(graphic_to_image(graphic).encodeToData()) as stream:
-        pil_image = PILImageMod.open(stream)
-        pil_image.load()  # Ensure to make a copy of buffer
-        return pil_image
+    return PILImageMod.fromarray(graphic_to_image(graphic).convert(alphaType=kUnpremul_AlphaType))
 
 
 # pylint: disable-next=invalid-name


### PR DESCRIPTION
Pick a strategy that does not make an expensive copy of the buffer each time ([list of strategies](https://github.com/kyamagu/skia-python/blob/e0b030c14e33f70880cfcc502eaeed898a77fc3c/notebooks/Python-Image-IO.ipynb)).

This process has to be done for each frame in animations.

Benchmark: on my machine, rendering 2K simple frames goes from 10.9s to 5.8s. The remaining slow part is encoding the GIF, done by Pillow.

```
Benchmark 1: python3 before.py
  Time (mean ± σ):     10.935 s ±  0.120 s    [User: 11.045 s, System: 2.041 s]
  Range (min … max):   10.807 s … 11.113 s    5 runs
Benchmark 1: python3 after.py
  Time (mean ± σ):      5.814 s ±  0.013 s    [User: 6.042 s, System: 2.118 s]
  Range (min … max):    5.800 s …  5.830 s    5 runs
```